### PR TITLE
node-expo-crypto can't run on Node 12

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,13 +5,12 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     strategy:
@@ -20,12 +19,12 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: npm install --global yarn
-    - run: yarn
-    - run: yarn workspace node-expo-crypto run check
-    - run: yarn workspace node-expo-crypto run check
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install --global yarn
+      - run: yarn
+      - run: yarn workspace node-expo-crypto run check
+      - run: yarn workspace node-expo-random run check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+## 1.0.1
+
+- Changed TypeScript `target` from `esnext` to `ES2019`. It makes `node-expo-crypto` possible to run on Node 12 environment.
+
+## 1.0.0
+
+- Initial release

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "esnext",
+    "target": "ES2019",
     "module": "commonjs",
     "declaration": true,
     "noEmit": true,


### PR DESCRIPTION
Changed TypeScript `target` from `esnext` to `ES2019`. It makes `node-expo-crypto` possible to run on Node 12 environment.