### PR TITLE
Work/include jest setup js

### DIFF
--- a/packages/node-expo-crypto/README.md
+++ b/packages/node-expo-crypto/README.md
@@ -1,6 +1,17 @@
 # node-expo-crypto
 
-The Node.js implementation for [expo-crypto](https://docs.expo.io/versions/latest/sdk/crypto/).
+The package `node-expo-crypto` provides the same interface of [`expo-crypto`](https://docs.expo.io/versions/latest/sdk/crypto/). So Thus, you can implement mocks that work as expected even in the Node environment.
+
+```js
+var crypto = require('node-expo-crypto');
+
+var data = 'hello';
+var digest = crypto.digestStringAsync('sha256', data);
+
+console.log(digest);
+```
+
+This library also contains default mocks for Jest. For details on how to configure, see below.
 
 ## Install
 
@@ -10,17 +21,6 @@ $ npm install --save-dev node-expo-crypto
 
 ## Jest configuration
 
-Create a setup file.
-
-```js
-jest.mock('expo-crypto/build/ExpoCrypto', () => ({
-  digestStringAsync: jest.fn((algorithm, data, options) => {
-    const crypto = require('node-expo-crypto');
-    return crypto.digestStringAsync(algorithm, data, options);
-  })
-}));
-```
-
 In your Jest configuration.
 
 ```json
@@ -28,7 +28,7 @@ In your Jest configuration.
   ...
   "json": {
     "setupFilesAfterEnv": [
-      "./test/setup/node-expo-crypto.js"
+      "node-expo-crypto/jest-setup.js"
     ]
   }
 }

--- a/packages/node-expo-crypto/package.json
+++ b/packages/node-expo-crypto/package.json
@@ -19,8 +19,8 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
-    "./dist",
-    "./jest-setup.js"
+    "dist",
+    "jest-setup.js"
   ],
   "scripts": {
     "check": "yarn run type && yarn run lint && yarn run test",

--- a/packages/node-expo-random/README.md
+++ b/packages/node-expo-random/README.md
@@ -1,6 +1,15 @@
 # node-expo-random
 
-The Node.js implementation for [expo-random](https://docs.expo.io/versions/latest/sdk/random/).
+The package `node-expo-random` provides the same interface of [`expo-random`](https://docs.expo.io/versions/latest/sdk/random/). So Thus, you can implement mocks that work as expected even in the Node environment.
+
+```js
+var random = require('node-expo-random');
+
+var bytes = random.getRandomBytes(8);
+console.log(bytes);
+```
+
+This library also contains default mocks for Jest. For details on how to configure, see below.
 
 ## Install
 
@@ -10,21 +19,6 @@ $ npm install --save-dev node-expo-random
 
 ## Jest configuration
 
-Create a setup file.
-
-```js
-jest.mock('expo-random/build/ExpoRandom', () => ({
-  getRandomBytes: jest.fn(byteCount => {
-    const random = require('node-expo-random');
-    return random.getRandomBytes(byteCount);
-  }),
-  getRandomBytesAsync: jest.fn(byteCount => {
-    const random = require('node-expo-random');
-    return random.getRandomBytesAsync(byteCount);
-  })
-}));
-```
-
 In your Jest configuration.
 
 ```json
@@ -32,7 +26,7 @@ In your Jest configuration.
   ...
   "json": {
     "setupFilesAfterEnv": [
-      "./test/setup/node-expo-random.js"
+      "node-expo-random/jest-setup.js"
     ]
   }
 }

--- a/packages/node-expo-random/package.json
+++ b/packages/node-expo-random/package.json
@@ -19,8 +19,8 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
-    "./dist",
-    "./jest-setup.js"
+    "dist",
+    "jest-setup.js"
   ],
   "scripts": {
     "check": "yarn run type && yarn run lint && yarn run test",


### PR DESCRIPTION
I was having trouble with the files specified in [files](https://docs.npmjs.com/cli/v6/configuring-npm/package-json#files) of `package.json` not being included in the packages uploaded to npm. The problem was solved. The way of writing `files` was wrong.

**Before the change, `files`**

```json:package.json
"files": [
  ". /dist",
  ". /jest-setup.js"], ".
],
```

This will include the `dist` directory, but not `jest-setup.js`.

**Modified `files`**.

```json:package.json
"files": [
  "dist",
  "jest-setup.js"
],
````

Removing the leading `. /` to include it.
