### PR TITLE
Fix examples in README

### DIFF
--- a/packages/node-expo-crypto/README.md
+++ b/packages/node-expo-crypto/README.md
@@ -2,16 +2,14 @@
 
 The package `node-expo-crypto` provides the same interface of [`expo-crypto`](https://docs.expo.io/versions/latest/sdk/crypto/). So Thus, you can implement mocks that work as expected even in the Node environment.
 
-```js
-var crypto = require('node-expo-crypto');
+```typescript
+const crypto = require('node-expo-crypto');
 
-var data = 'hello';
-var digest = crypto.digestStringAsync('sha256', data);
-
-console.log(digest);
+const digest = await crypto.digestStringAsync('sha256', 'hello');
+console.log(digest); // 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
 ```
 
-This library also contains default mocks for Jest. For details on how to configure, see below.
+This package also contains default mocks for [Jest](https://jestjs.io/) testing framework. For details on how to configure, see below.
 
 ## Install
 

--- a/packages/node-expo-random/README.md
+++ b/packages/node-expo-random/README.md
@@ -2,10 +2,10 @@
 
 The package `node-expo-random` provides the same interface of [`expo-random`](https://docs.expo.io/versions/latest/sdk/random/). So Thus, you can implement mocks that work as expected even in the Node environment.
 
-```js
-var random = require('node-expo-random');
+```typescript
+const random = require('node-expo-random');
 
-var bytes = random.getRandomBytes(8);
+const bytes = random.getRandomBytes(8);
 console.log(bytes); // Uint8Array(8) [5, 169, 234, 152, 41, 248, 121, 197]
 ```
 

--- a/packages/node-expo-random/README.md
+++ b/packages/node-expo-random/README.md
@@ -6,10 +6,10 @@ The package `node-expo-random` provides the same interface of [`expo-random`](ht
 var random = require('node-expo-random');
 
 var bytes = random.getRandomBytes(8);
-console.log(bytes);
+console.log(bytes); // Uint8Array(8) [5, 169, 234, 152, 41, 248, 121, 197]
 ```
 
-This library also contains default mocks for Jest. For details on how to configure, see below.
+This package also contains default mocks for [Jest](https://jestjs.io/) testing framework. For details on how to configure, see below.
 
 ## Install
 


### PR DESCRIPTION
The code examples in the README were wrong, although I didn't notice it when I released it before. Also, the language used in the examples has been changed to TypeScript.